### PR TITLE
Removed "Caveats" section in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,12 +17,6 @@ You can also `git clone` or [download](https://github.com/sindresorhus/electron-
 
 There's also a [Yeoman generator](https://github.com/sindresorhus/generator-electron).
 
-
-## Caveats
-
-Only OS X is supported for the `$ npm run build` command for now, see [atom-shell-packager#3](https://github.com/maxogden/atom-shell-packager/issues/3).
-
-
 ## License
 
 MIT © [Sindre Sorhus](http://sindresorhus.com)


### PR DESCRIPTION
The caveat about `npm run build` is no longer valid.
