### PR TITLE
Remove electron-debug

### DIFF
--- a/boilerplate/index.js
+++ b/boilerplate/index.js
@@ -5,9 +5,6 @@ const BrowserWindow = require('browser-window');
 // report crashes to the Electron project
 require('crash-reporter').start();
 
-// adds debug features like hotkeys for triggering dev tools and reload
-require('electron-debug')();
-
 // prevent window being garbage collected
 let mainWindow;
 


### PR DESCRIPTION
electron-debug is no longer necessary. in fact, electron will crash running it.
