### PR TITLE
Add `npm-debug.log` to `.gitignore`

### DIFF
--- a/boilerplate/.gitignore
+++ b/boilerplate/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 /dist
+npm-debug.log


### PR DESCRIPTION
I think we should also ignore `npm-debug.log` for git.
