### PR TITLE
'activate-with-no-open-windows' event deprecated

### DIFF
--- a/boilerplate/index.js
+++ b/boilerplate/index.js
@@ -35,7 +35,7 @@ app.on('window-all-closed', () => {
 	}
 });
 
-app.on('activate-with-no-open-windows', () => {
+app.on('activate', () => {
 	if (!mainWindow) {
 		mainWindow = createMainWindow();
 	}


### PR DESCRIPTION
Console message when running electron:

`(electron) 'activate-with-no-open-windows' event is deprecated. Use 'activate' event instead.`
