### PR TITLE
Fix Cannot find electron-debug

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -22,6 +22,7 @@
     "devtron": "^1.1.0",
     "electron-packager": "^8.0.0",
     "electron": "^1.6.6",
+    "electron-debug": "^1.1.0",
     "xo": "^0.18.0"
   },
   "xo": {


### PR DESCRIPTION
When curling the files from the README instructions, project fails to
run because the application expected electron-debug package to be
installed. Should be in the package.json of the boilerplate from the
start.