### PR TITLE
dependency updates + correct file url format on windows

### DIFF
--- a/boilerplate/index.js
+++ b/boilerplate/index.js
@@ -21,7 +21,13 @@ function createMainWindow() {
 		height: 400
 	});
 
-	win.loadURL(`file://${__dirname}/index.html`);
+	const url = require('url').format({
+		protocol: 'file',
+		slashes: true,
+		pathname: require('path').join(__dirname, 'index.html')
+	});
+
+	win.loadURL(url);
 	win.on('closed', onClosed);
 
 	return win;

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -16,13 +16,13 @@
     "build": "electron-packager . --out=dist --asar --overwrite --all"
   },
   "dependencies": {
-    "electron-debug": "^1.0.0"
+    "electron-debug": "^1.2.0"
   },
   "devDependencies": {
-    "devtron": "^1.1.0",
-    "electron-packager": "^8.0.0",
-    "electron": "^1.6.6",
-    "xo": "^0.18.0"
+    "devtron": "^1.4.0",
+    "electron-packager": "^8.7.2",
+    "electron": "^1.6.11",
+    "xo": "^0.18.2"
   },
   "xo": {
     "envs": [


### PR DESCRIPTION
 * electron 1.6.11 includes a security fix
 * url parameter is formatted following the suggestion from the documentation: https://github.com/electron/electron/blob/master/docs/api/browser-window.md#winloadurlurl-options