### PR TITLE
Correctly await main window creation on activate

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,9 +74,9 @@ app.on('window-all-closed', () => {
 	}
 });
 
-app.on('activate', () => {
+app.on('activate', async () => {
 	if (!mainWindow) {
-		mainWindow = createMainWindow();
+		mainWindow = await createMainWindow();
 	}
 });
 


### PR DESCRIPTION
Correctly await main window creation on activate.

As createMainWindow() returns a Promise, the direct assignment to `mainWindow` in the callback to "activate" would actually assign the Promise to `mainWindow`. This PR should fix this little issue.