### PR TITLE
Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,16 +20,16 @@
 		"release": "np"
 	},
 	"dependencies": {
-		"electron-context-menu": "^0.12.1",
+		"electron-context-menu": "^0.15.0",
 		"electron-debug": "^3.0.0",
-		"electron-store": "^3.3.0",
-		"electron-unhandled": "^2.2.0",
+		"electron-store": "^4.0.0",
+		"electron-unhandled": "^3.0.0",
 		"electron-updater": "^4.0.6",
 		"electron-util": "^0.12.0"
 	},
 	"devDependencies": {
-		"electron": "^5.0.4",
-		"electron-builder": "^20.43.0",
+		"electron": "^6.0.7",
+		"electron-builder": "^21.2.0",
 		"np": "^5.0.3",
 		"xo": "^0.24.0"
 	},


### PR DESCRIPTION
* electron@6.0.7
* electron-builder@21.2.0
* electron-context-menu@0.15.0
* electron-store@4.0.0
* electron-unhandled@3.0.0

Tested `npm start`, `npm pack`, `npm lint`, `npm dist`. All worked.

fixes #27 