### PR TITLE
Add devtron in development mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,10 @@ const createMainWindow = async () => {
 		title: app.getName(),
 		show: false,
 		width: 600,
-		height: 400
+		height: 400,
+		webPreferences: {
+			preload: path.join(__dirname, 'preload.js')
+		}
 	});
 
 	win.on('ready-to-show', () => {
@@ -57,6 +60,12 @@ const createMainWindow = async () => {
 if (!app.requestSingleInstanceLock()) {
 	app.quit();
 }
+
+app.on('ready', () => {
+	if (process.env.NODE_ENV === 'development') {
+		require('devtron').install();
+	}
+});
 
 app.on('second-instance', () => {
 	if (mainWindow) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"electron-util": "^0.13.0"
 	},
 	"devDependencies": {
+		"devtron": "^1.4.0",
 		"electron": "^7.1.1",
 		"electron-builder": "^21.2.0",
 		"np": "^5.0.3",

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,1 @@
+window.__devtron = {require: require, process: process};

--- a/preload.js
+++ b/preload.js
@@ -1,1 +1,2 @@
-window.__devtron = {require: require, process: process};
+// You can remove this if you do have nodeIntegration enabled.
+require('electron-debug/preload');


### PR DESCRIPTION
This PR adds the [devtron](https://electronjs.org/devtron) extension in development mode.