### PR TITLE
Minor simplification

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -167,7 +167,7 @@ const otherTemplate = [
 	}
 ];
 
-const template = process.platform === 'darwin' ? macosTemplate : otherTemplate;
+const template = is.macos ? macosTemplate : otherTemplate;
 
 if (is.development) {
 	template.push({


### PR DESCRIPTION
Replaced `process.platform === 'darwin'` for `is.macos`, as those are [functionally equal](https://github.com/sindresorhus/electron-util/blob/e73e150194f0da00baacf4beff455d5e043cd9ab/source/is.js#L6).